### PR TITLE
disconnect any running processes before starting

### DIFF
--- a/tasks/hapi.js
+++ b/tasks/hapi.js
@@ -18,13 +18,13 @@ module.exports = function(grunt) {
       noasync: false
     });
 
-    while (all_running.length) {        
-        all_running.pop().disconnect();
+    if (all_running[this.target]) {
+      all_running[this.target].disconnect();
     }
 
     // Starting a child process to launch the server in
     running = require('child_process').fork(__dirname + '/../lib/forkme');
-    all_running.push(running);
+    all_running[this.target] = running;
 
     running.send(options);
 


### PR DESCRIPTION
Prior to my modification, when grunt-contrib-watch tried to run the hapi task again, an EADDRINUSE error was thrown. In the original hapi.js, "running" will always be undefined as nothing has been assigned to it.

I'm not sure why there's an array of running processes - but calling disconnect makes sense and fixes the error.
