### PR TITLE
Change Base to Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ The options object that would be used if `server` option provided to `grunt-hapi
 
 #### options.bases
 Type: `Object`
-Default value: `{'/': '.'}`
+Default value: `null`
+Example value: `{'/': './public'}`
 
 Key/Value pair that associate a URI path from where you want to access static files with a FilePath that point to a directory where Hapi can find these static files.
 

--- a/tasks/hapi.js
+++ b/tasks/hapi.js
@@ -15,14 +15,14 @@ module.exports = function(grunt) {
       server: null,
       port: null,
       create_options: null,
-      bases: {'/': '.'},
+      bases: null,
       noasync: false
     });
 
     if (all_running[this.target]) {
       all_running[this.target].disconnect();
     }
- 
+
     // Starting a child process to launch the server in
     running = require('child_process').fork(__dirname + '/../lib/forkme');
     all_running[this.target] = running;


### PR DESCRIPTION
If a hapi server already has a default static route, it may be preferable to allow base to be optional.

I'm not really expecting you to merge this P.R. - it is just a conversation starter on https://github.com/athieriot/grunt-hapi/issues/9 . But if you like it, go ahead and merge and publish to npm. 

I checked the tests and they still pass. 