### PR TITLE
Updated hapi to version 10.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-nodeunit": "0.4.1",
     "grunt": "0.4.5",
     "inert": "3.0.2",
-    "hapi": "10.2.1",
+    "hapi": "10.3.0",
     "follow-redirects": "0.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
:rocket:

hapi just published version 10.3.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [e799439](https://github.com/hapijs/hapi/commit/e7994395247c3cedb757203072baaf1cee34e8c2): add connection inside plugin. Closes #2754
- [9a8ab52](https://github.com/hapijs/hapi/commit/9a8ab527f25859296394e216a396657aea91db39): Update API.md
- [25f6d1b](https://github.com/hapijs/hapi/commit/25f6d1bac3b0876c47af29a7c11b7cb1c349b762): Update API.md

See the [full diff](https://github.com/hapijs/hapi/compare/fc2f49de5895963af494d5fa3a3f7010ffb294b5...e7994395247c3cedb757203072baaf1cee34e8c2).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>