### PR TITLE
Updated inert to version 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-contrib-clean": "0.5.0",
     "grunt-contrib-nodeunit": "0.4.1",
     "grunt": "0.4.5",
-    "inert": "3.0.2",
+    "inert": "3.1.0",
     "hapi": "10.4.0",
     "follow-redirects": "0.0.3"
   },


### PR DESCRIPTION
:rocket:

inert just published version 3.1.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 6 commits (ahead by 6, behind by 0).

- [c4c0772](https://github.com/hapijs/inert/commit/c4c077282463adf0c915d492b50c4887d6053c4d): 3.1.0
- [ae8cd8e](https://github.com/hapijs/inert/commit/ae8cd8e2de72c6c8f84cbd36e138321f2fae0254): Apply new plugin attributes. Closes #43
- [e21b098](https://github.com/hapijs/inert/commit/e21b09829e51cf3b332a81acd368d4004fd08067): Update to lab@6.x
- [4a54ac0](https://github.com/hapijs/inert/commit/4a54ac0ef08440e0207347db77ba6c7ba970caf8): Update lru-cache to 2.7.x
- [cbbf556](https://github.com/hapijs/inert/commit/cbbf55679c8eff36e8ff60c03f4058b0d59652be): Ensure a compatible version of joi is installed
- [9911f4d](https://github.com/hapijs/inert/commit/9911f4d715910f21ce9b9520cfa2f3ad0bd3b0bd): Test using hapi-lts@10.x whenever possible. Closes #44

See the [full diff](https://github.com/hapijs/inert/compare/a65c7317e14d150e98b2e7b201926b15cc723dcb...c4c077282463adf0c915d492b50c4887d6053c4d).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>